### PR TITLE
Add unk token for unknown words

### DIFF
--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -9,8 +9,8 @@ class Tokenizer:
     """Whitespace tokenizer with vocabulary management."""
 
     def __init__(self) -> None:
-        self.token_to_id = {"<pad>": 0, "<bos>": 1, "<eos>": 2}
-        self.id_to_token = {0: "<pad>", 1: "<bos>", 2: "<eos>"}
+        self.token_to_id = {"<pad>": 0, "<bos>": 1, "<eos>": 2, "<unk>": 3}
+        self.id_to_token = {0: "<pad>", 1: "<bos>", 2: "<eos>", 3: "<unk>"}
 
     def build_vocab_from_texts(self, texts: List[str]) -> None:
         """Add tokens from the provided texts to the vocabulary."""
@@ -28,7 +28,7 @@ class Tokenizer:
     def encode(self, text: str, max_len: int) -> np.ndarray:
         """Convert text to a sequence of token ids."""
         tokens = ["<bos>"] + self.tokenize(text) + ["<eos>"]
-        ids = [self.token_to_id.get(t, self.token_to_id["<pad>"]) for t in tokens]
+        ids = [self.token_to_id.get(t, self.token_to_id["<unk>"]) for t in tokens]
         if len(ids) < max_len:
             ids += [self.token_to_id["<pad>"]] * (max_len - len(ids))
         else:

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -8,3 +8,10 @@ def test_tokenizer_basic():
     tok.build_vocab_from_texts(["hallo", "welt"])
     assert tok.encode("hallo", 4).tolist()[1] == tok.token_to_id["hallo"]
     assert tok.decode([tok.token_to_id["welt"], 0]) == "welt"
+
+
+def test_unknown_token_maps_to_unk():
+    tok = Tokenizer()
+    tok.build_vocab_from_texts(["hallo"])
+    ids = tok.encode("foo", 4)
+    assert ids[1] == tok.token_to_id["<unk>"]


### PR DESCRIPTION
## Summary
- include `<unk>` in default vocabulary
- encode unknown tokens as `<unk>`
- test that unknown tokens map to `<unk>`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841532a26388325b1154231ff2c1890