### PR TITLE
Include decoder cross-attention weights in params

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -20,14 +20,30 @@ class Seq2SeqTransformer:
             self.decoder.embedding,
             self.decoder.fc_out,
         ]
-        for layer in self.encoder.layers + self.decoder.layers:
-            self.params.extend([
-                layer.self_attn.W_q,
-                layer.self_attn.W_k,
-                layer.self_attn.W_v,
-                layer.self_attn.W_o,
-                getattr(layer, "cross_attn", layer.self_attn).W_q,
-            ])
+        for layer in self.encoder.layers:
+            self.params.extend(
+                [
+                    layer.self_attn.W_q,
+                    layer.self_attn.W_k,
+                    layer.self_attn.W_v,
+                    layer.self_attn.W_o,
+                    layer.self_attn.W_q,  # placeholder for cross-attention
+                ]
+            )
+
+        for layer in self.decoder.layers:
+            self.params.extend(
+                [
+                    layer.self_attn.W_q,
+                    layer.self_attn.W_k,
+                    layer.self_attn.W_v,
+                    layer.self_attn.W_o,
+                    layer.cross_attn.W_q,
+                    layer.cross_attn.W_k,
+                    layer.cross_attn.W_v,
+                    layer.cross_attn.W_o,
+                ]
+            )
 
     def encode(self, src_ids: np.ndarray, src_mask: Optional[np.ndarray]) -> np.ndarray:
         return self.encoder(src_ids, src_mask)

--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -1,0 +1,13 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+from src.model import Seq2SeqTransformer
+from src.utils import Config
+
+
+def test_cross_attention_params_present():
+    cfg = Config()
+    model = Seq2SeqTransformer(cfg)
+    for layer in model.decoder.layers:
+        assert any(p is layer.cross_attn.W_k for p in model.params)
+        assert any(p is layer.cross_attn.W_v for p in model.params)
+        assert any(p is layer.cross_attn.W_o for p in model.params)


### PR DESCRIPTION
## Summary
- track decoder cross-attention weights in `Seq2SeqTransformer.params`
- add test ensuring new parameters are included

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684153277c0083258dce6355a496bcd8